### PR TITLE
#130: 'new user' page as dialog

### DIFF
--- a/src/app/pages/admin/users/user-details/user-details.component.html
+++ b/src/app/pages/admin/users/user-details/user-details.component.html
@@ -4,7 +4,7 @@
       <h1 class="mb-10 mt-0">
         {{ id ? "User Details" : "Create User" }}
       </h1>
-      <a routerLink="/admin/users/list" class="go-back">
+      <a routerLink="/admin/users/list" class="go-back" *ngIf="id">
         <div fxFlex fxLayoutAlign="start center">
           <mat-icon>arrow_back</mat-icon>
           <span>Back to List</span>

--- a/src/app/pages/admin/users/users-list/users-list.component.html
+++ b/src/app/pages/admin/users/users-list/users-list.component.html
@@ -4,10 +4,15 @@
       <h1 class="mb-0 mt-0">Users</h1>
     </div>
     <div fxFlex fxLayoutAlign="end">
-      <a routerLink="/admin/users/new" mat-raised-button color="primary">
+      <button
+        mat-flat-button
+        type="button"
+        color="primary"
+        (click)="openNewUserDialog()"
+      >
         <mat-icon>add</mat-icon>
         Nou user
-      </a>
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/pages/admin/users/users-routing.module.ts
+++ b/src/app/pages/admin/users/users-routing.module.ts
@@ -23,10 +23,6 @@ const routes: Routes = [
         component: UsersListComponent,
       },
       {
-        path: 'new',
-        component: UserDetailsComponent,
-      },
-      {
         path: '**',
         redirectTo: 'list',
         pathMatch: 'full',


### PR DESCRIPTION
Closes #130 

Open new user form in dialog rather then in new page. Removed new user route. I did not see a way a way to subscribe to the update success so the dialog will remain open after save. 