### PR TITLE
feat: lift "new request" page into a dialog

### DIFF
--- a/src/app/pages/admin/requests/request-details/request-details.component.html
+++ b/src/app/pages/admin/requests/request-details/request-details.component.html
@@ -8,7 +8,7 @@
             : "Create Beneficiar"
         }}
       </h1>
-      <a href="#" appGoBack class="go-back">
+      <a href="#" appGoBack class="go-back" *ngIf="currentRequestId$ | async">
         <div fxFlex fxLayoutAlign="start center">
           <mat-icon>arrow_back</mat-icon>
           <span>Back to List</span>

--- a/src/app/pages/admin/requests/requests-list/requests-list.component.html
+++ b/src/app/pages/admin/requests/requests-list/requests-list.component.html
@@ -13,15 +13,16 @@
         <mat-icon>cloud_download</mat-icon>
         Export Excel
       </button>
-      <a
-        routerLink="/admin/requests/new"
+      <button
         mat-flat-button
+        type="button"
         color="primary"
         class="large"
+        (click)="openNewRequestDialog()"
       >
         <mat-icon>add</mat-icon>
         New Request
-      </a>
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/pages/admin/requests/requests-routing.module.ts
+++ b/src/app/pages/admin/requests/requests-routing.module.ts
@@ -21,11 +21,6 @@ const routes: Routes = [
         component: RequestDetailsComponent,
       },
       {
-        path: 'new',
-        canActivateChild: [DelayGuard],
-        component: RequestDetailsComponent,
-      },
-      {
         path: 'list',
         component: RequestsListComponent,
       },

--- a/src/app/root-store/requests-store/effects.ts
+++ b/src/app/root-store/requests-store/effects.ts
@@ -74,7 +74,6 @@ export class RequestsEffects {
         const { _id, ...withoutId } = payload;
         return this.requestService.saveRequest(withoutId).pipe(
           map((res) => {
-            this.router.navigate(['/requests/details', res._id]);
             return saveRequestSuccessAction({ payload: res });
           }),
           catchError((error) => of(saveRequestFailureAction({ error })))

--- a/src/app/services/requests/requests-facade.service.ts
+++ b/src/app/services/requests/requests-facade.service.ts
@@ -29,6 +29,8 @@ import {
 } from 'rxjs/operators';
 import { BehaviorSubject, interval, Subject, combineLatest } from 'rxjs';
 
+export type RequestPageParams = { pageSize: number; pageIndex: number };
+
 @Injectable({
   providedIn: 'root',
 })
@@ -92,7 +94,7 @@ export class RequestsFacadeService {
     this.hasNewRequests$.next(false);
   }
 
-  getRequests(page: { pageSize: number; pageIndex: number }, filters?: any) {
+  getRequests(page: RequestPageParams, filters?: any) {
     this.store.dispatch(getRequestsAction({ page, filters }));
   }
 


### PR DESCRIPTION
Closes #125 

After request is saved in dialog, request list is updated with the currently applied filters, status counts updated, and dialog is closed.