### PR TITLE
 feat: create expandable map on requests admin page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,6 +1817,12 @@
         "semver-intersect": "1.4.0"
       }
     },
+    "@types/arcgis-js-api": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/arcgis-js-api/-/arcgis-js-api-4.16.0.tgz",
+      "integrity": "sha512-AAXUeyzF2PxtjKOO/Zqffq/mLpNp/uVaKwqq/n8ayqsqOGtffNDBTrfeUDvaFnrox8oTVFhDIAEObZHJNxwFgA==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^14.11.8",
+    "@types/arcgis-js-api": "^4.16.0",
     "codelyzer": "^6.0.1",
     "husky": "^4.3.0",
     "jasmine-core": "~3.6.0",

--- a/src/app/pages/admin/requests/requests-list/requests-list.component.html
+++ b/src/app/pages/admin/requests/requests-list/requests-list.component.html
@@ -33,6 +33,16 @@
   (queryResult)="queryResult($event)"
 ></app-filter>
 
+<mat-expansion-panel hideToggle class="map-expansion-panel">
+  <mat-expansion-panel-header>
+    <mat-panel-title class="d-flex justify-content-center">
+      <mat-icon>map</mat-icon>
+      <span class="ml-1">Hartă</span>
+    </mat-panel-title>
+  </mat-expansion-panel-header>
+  <app-requests-map></app-requests-map>
+</mat-expansion-panel>
+
 <mat-tab-group
   [selectedIndex]="selectedTabIndex$ | async"
   mat-stretch-tabs

--- a/src/app/pages/admin/requests/requests-list/requests-list.component.scss
+++ b/src/app/pages/admin/requests/requests-list/requests-list.component.scss
@@ -308,3 +308,10 @@ tr {
     }
   }
 }
+
+// fill full size of container
+::ng-deep.map-expansion-panel {
+  .mat-expansion-panel-body {
+    padding: 0px;
+  }
+}

--- a/src/app/pages/admin/requests/requests-map/requests-map.component.html
+++ b/src/app/pages/admin/requests/requests-map/requests-map.component.html
@@ -1,0 +1,8 @@
+<div class="d-flex">
+  <map #map></map>
+
+  <div fxFlex="25" class="mt-3">
+    <div fxLayoutAlign="center">Selectare Beneficiari</div>
+    <!-- TODO  -->
+  </div>
+</div>

--- a/src/app/pages/admin/requests/requests-map/requests-map.component.scss
+++ b/src/app/pages/admin/requests/requests-map/requests-map.component.scss
@@ -1,0 +1,7 @@
+@import "https://js.arcgis.com/4.14/esri/themes/light/main.css";
+
+:host,
+map {
+  height: 500px;
+  width: 100%;
+}

--- a/src/app/pages/admin/requests/requests-map/requests-map.component.spec.ts
+++ b/src/app/pages/admin/requests/requests-map/requests-map.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RequestsMapComponent } from './requests-map.component';
+
+describe('RequestsMapComponent', () => {
+  let component: RequestsMapComponent;
+  let fixture: ComponentFixture<RequestsMapComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RequestsMapComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RequestsMapComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/admin/requests/requests-map/requests-map.component.ts
+++ b/src/app/pages/admin/requests/requests-map/requests-map.component.ts
@@ -1,0 +1,97 @@
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { loadModules } from 'esri-loader';
+import { from } from 'rxjs';
+import esri = __esri; // Esri TypeScript Types
+
+@Component({
+  selector: 'app-requests-map',
+  templateUrl: './requests-map.component.html',
+  styleUrls: ['./requests-map.component.scss'],
+})
+export class RequestsMapComponent implements OnDestroy, OnInit {
+  @Input() coors: [number, number] = [47.01266177894471, 28.825140232956283];
+  @Output() mapLoadedEvent = new EventEmitter<boolean>();
+
+  @ViewChild('map', { static: true }) private mapViewEl: ElementRef;
+
+  private loaded: boolean;
+  private search: esri.Search;
+  private view: esri.MapView = null;
+
+  constructor() {}
+
+  ngOnInit() {
+    // Initialize MapView and return an instance of MapView
+    from(this.initializeMap()).subscribe((mapView) => {
+      // The map has been initialized
+      this.loaded = this.view.ready;
+      this.mapLoadedEvent.emit(true);
+    });
+  }
+
+  async initializeMap() {
+    try {
+      const [Map, MapView, Search, BasemapToggle]: [
+        esri.MapConstructor,
+        esri.MapViewConstructor,
+        esri.SearchConstructor,
+        esri.BasemapToggleConstructor
+      ] = await loadModules([
+        'esri/Map',
+
+        'esri/views/MapView',
+        'esri/widgets/Search',
+        'esri/widgets/BasemapToggle',
+      ]);
+
+      const map = new Map({ basemap: 'streets-navigation-vector' });
+      this.view = new MapView({
+        container: this.mapViewEl.nativeElement,
+        zoom: 12,
+        map,
+      });
+
+      this.search = new Search();
+      this.view.ui.add([this.search], 'top-right');
+      this.view.ui.add(
+        new BasemapToggle({ view: this.view, nextBasemap: 'hybrid' }),
+        'bottom-left'
+      );
+
+      this.view.when(
+        async () => {
+          const [latitude, longitude] = this.coors;
+          await this.view.goTo(
+            [
+              latitude || 47.01266177894471,
+              longitude || 28.825140232956283,
+            ].reverse()
+          );
+        },
+        (error: any) => {
+          throw new Error(error);
+        }
+      );
+
+      return this.view;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.view) {
+      // destroy the map view
+      this.view.container = null;
+    }
+  }
+}

--- a/src/app/pages/admin/requests/requests.module.ts
+++ b/src/app/pages/admin/requests/requests.module.ts
@@ -9,6 +9,7 @@ import { SharedModule } from '@shared/shared.module';
 import { RequestModalInfoComponent } from './request-modal-info/request-modal-info.component';
 import { RequestFormComponent } from './request-form/request-form.component';
 import { NgxMaskModule, IConfig } from 'ngx-mask';
+import { RequestsMapComponent } from './requests-map/requests-map.component';
 
 @NgModule({
   declarations: [
@@ -17,6 +18,7 @@ import { NgxMaskModule, IConfig } from 'ngx-mask';
     RequestsListComponent,
     RequestModalInfoComponent,
     RequestFormComponent,
+    RequestsMapComponent,
   ],
   imports: [
     CommonModule,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": ["arcgis-js-api"]
   },
   "files": ["src/main.ts", "src/polyfills.ts"],
   "include": ["src/**/*.d.ts"]

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": ["jasmine"]
+    "types": ["jasmine", "arcgis-js-api"]
   },
   "files": ["src/test.ts", "src/polyfills.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]


### PR DESCRIPTION
Closes #128 

Add expandable map component to requests page. Included [arcgis-js-api types](https://github.com/Esri/jsapi-resources/tree/master/4.x/typescript) for improved map development.

![requests list map](https://user-images.githubusercontent.com/3781615/95690126-7dbdbb00-0be3-11eb-9a70-886032f2ea59.png)
