### PR TITLE
refactor: add admin page header component

### DIFF
--- a/src/app/admin/volunteers/volunteers-details/volunteers-details.component.html
+++ b/src/app/admin/volunteers/volunteers-details/volunteers-details.component.html
@@ -1,7 +1,7 @@
 <app-admin-page-header
   *ngIf="volunteer$ | async as volunteer"
   title="view_volunteer"
-  [editLink]="['/admin/volunteers', volunteer._id, 'edit']"
+  editLink="edit"
 ></app-admin-page-header>
 
 <div

--- a/src/app/admin/volunteers/volunteers-details/volunteers-details.component.html
+++ b/src/app/admin/volunteers/volunteers-details/volunteers-details.component.html
@@ -1,17 +1,8 @@
-<div class="mt-4 mb-3">
-  <a href="#" appGoBack>
-    <-
-    <span translate>back</span>
-  </a>
-</div>
-
-<div class="d-flex mb-4 align-items-center">
-  <h2 translate>view_volunteer</h2>
-  <a routerLink="edit" mat-stroked-button color="primary" class="ml-auto">
-    <mat-icon>border_color</mat-icon>
-    {{ "edit" | translate }}
-  </a>
-</div>
+<app-admin-page-header
+  *ngIf="volunteer$ | async as volunteer"
+  title="view_volunteer"
+  [editLink]="['/admin/volunteers', volunteer._id, 'edit']"
+></app-admin-page-header>
 
 <div
   class="bg-white p-4 mat-typography"

--- a/src/app/admin/volunteers/volunteers-edit/volunteers-edit.component.html
+++ b/src/app/admin/volunteers/volunteers-edit/volunteers-edit.component.html
@@ -1,11 +1,4 @@
-<div class="mt-4 mb-3">
-  <a href="#" appGoBack>
-    <-
-    <span translate>back</span>
-  </a>
-</div>
-
-<h2 class="mb-4" translate>volunteer_edit</h2>
+<app-admin-page-header title="volunteer_edit"></app-admin-page-header>
 
 <form [formGroup]="formGroup" (ngSubmit)="onSubmit(formGroup)" class="pb-4">
   <div class="bg-white p-4 mat-typography">

--- a/src/app/admin/volunteers/volunteers-list/volunteers-list.component.html
+++ b/src/app/admin/volunteers/volunteers-list/volunteers-list.component.html
@@ -1,9 +1,9 @@
 <app-admin-page-header
-  title="Voluntari"
+  title="volunteers"
   (importCallback)="onVolunteersImport()"
   (exportCallback)="onVolunteersExport()"
   (addCallback)="openNewVolunteerDialog()"
-  addBtnLabel="Adaugă voluntar"
+  addBtnLabel="add_volunteer"
 ></app-admin-page-header>
 
 <mat-card class="mb-4">

--- a/src/app/admin/volunteers/volunteers-list/volunteers-list.component.html
+++ b/src/app/admin/volunteers/volunteers-list/volunteers-list.component.html
@@ -1,42 +1,10 @@
-<h2 class="mt-5 mb-2" fxLayoutAlign="space-between center">Voluntari</h2>
-
-<div class="mb-2 d-flex flex-column flex-sm-row flex-wrap">
-  <div>
-    <button
-      mat-flat-button
-      type="button"
-      color="default"
-      disabled
-      class="mb-1 mr-sm-2"
-      (click)="onVolunteersImport()"
-    >
-      <mat-icon>publish</mat-icon>
-      Import
-    </button>
-
-    <button
-      mat-flat-button
-      type="button"
-      color="default"
-      class="mb-1 mr-sm-2"
-      (click)="onVolunteersExport()"
-    >
-      <mat-icon>get_app</mat-icon>
-      Export
-    </button>
-  </div>
-
-  <button
-    mat-flat-button
-    type="button"
-    color="primary"
-    (click)="openNewVolunteerDialog()"
-    class="mb-1 ml-sm-auto"
-  >
-    <mat-icon>add</mat-icon>
-    Adaugă voluntar
-  </button>
-</div>
+<app-admin-page-header
+  title="Voluntari"
+  (importCallback)="onVolunteersImport()"
+  (exportCallback)="onVolunteersExport()"
+  (addCallback)="openNewVolunteerDialog()"
+  addBtnLabel="Adaugă voluntar"
+></app-admin-page-header>
 
 <mat-card class="mb-4">
   <form

--- a/src/app/shared/components/admin-page-header/admin-page-header.component.html
+++ b/src/app/shared/components/admin-page-header/admin-page-header.component.html
@@ -1,0 +1,65 @@
+<div class="mt-4 mb-3">
+  <a
+    href="#"
+    appGoBack
+    mat-stroked-button
+    color="primary"
+    *ngIf="!addCallback.observers.length"
+  >
+    <mat-icon>arrow_back</mat-icon>
+    <span translate>back</span>
+  </a>
+</div>
+
+<div class="mb-4 d-flex justify-content-between">
+  <div class="flex-column">
+    <h2 translate>{{ title }}</h2>
+    <div class="d-flex">
+      <button
+        *ngIf="importCallback.observers.length"
+        mat-flat-button
+        type="button"
+        color="default"
+        class="mr-sm-2"
+        (click)="importCallback.emit()"
+      >
+        <mat-icon>publish</mat-icon>
+        Import
+      </button>
+
+      <button
+        *ngIf="exportCallback.observers.length"
+        mat-flat-button
+        type="button"
+        color="default"
+        class="mr-sm-2"
+        (click)="exportCallback.emit()"
+      >
+        <mat-icon>get_app</mat-icon>
+        Export
+      </button>
+    </div>
+  </div>
+  <div class="mt-auto">
+    <a
+      *ngIf="editLink"
+      [routerLink]="editLink"
+      mat-stroked-button
+      color="primary"
+    >
+      <mat-icon>border_color</mat-icon>
+      {{ "edit" | translate }}
+    </a>
+
+    <button
+      *ngIf="addBtnLabel && addCallback.observers.length"
+      mat-flat-button
+      type="button"
+      color="primary"
+      (click)="addCallback.emit()"
+    >
+      <mat-icon>add</mat-icon>
+      {{ addBtnLabel }}
+    </button>
+  </div>
+</div>

--- a/src/app/shared/components/admin-page-header/admin-page-header.component.html
+++ b/src/app/shared/components/admin-page-header/admin-page-header.component.html
@@ -59,7 +59,7 @@
       (click)="addCallback.emit()"
     >
       <mat-icon>add</mat-icon>
-      {{ addBtnLabel }}
+      {{ addBtnLabel | translate }}
     </button>
   </div>
 </div>

--- a/src/app/shared/components/admin-page-header/admin-page-header.component.ts
+++ b/src/app/shared/components/admin-page-header/admin-page-header.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-admin-page-header',
+  templateUrl: './admin-page-header.component.html',
+})
+export class AdminPageHeaderComponent {
+  @Input()
+  editLink: any[] | string | null | undefined;
+  @Input()
+  title: string;
+  @Input()
+  addBtnLabel: string;
+  @Output()
+  addCallback = new EventEmitter<any>();
+  @Output()
+  importCallback = new EventEmitter<any>();
+  @Output()
+  exportCallback = new EventEmitter<any>();
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -10,6 +10,8 @@ import { PrettyDatePipe } from './pretty-date.pipe';
 import { AppBadgeComponent } from './app-badge/app-badge.component';
 import { ReadOnlyInputComponent } from '@shared/components/read-only-input/read-only-input.component';
 import { TranslateModule } from '@ngx-translate/core';
+import { AdminPageHeaderComponent } from './components/admin-page-header/admin-page-header.component';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
   imports: [
@@ -19,6 +21,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MaterialComponentsModule,
     FlexLayoutModule,
     TranslateModule,
+    RouterModule,
   ],
   exports: [
     CommonModule,
@@ -33,6 +36,7 @@ import { TranslateModule } from '@ngx-translate/core';
     PrettyDatePipe,
     AppBadgeComponent,
     ReadOnlyInputComponent,
+    AdminPageHeaderComponent,
   ],
   declarations: [
     EsriMapComponent,
@@ -41,6 +45,7 @@ import { TranslateModule } from '@ngx-translate/core';
     PrettyDatePipe,
     AppBadgeComponent,
     ReadOnlyInputComponent,
+    AdminPageHeaderComponent,
   ],
 })
 export class SharedModule {}

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -77,6 +77,7 @@
   "no_volunteers": "Lipsă voluntari",
   "view_user": "Vezi utilizator",
   "view_volunteer": "Vezi voluntar",
+  "add_volunteer": "Adaugă voluntar",
   "edit": "Editează",
   "demands_history": "Istoric cereri",
   "created_at": "Creat la",


### PR DESCRIPTION
use one component for header that can be configured with go back, import, export, view, edit functionalities/callbacks
this should be used in all admin pages for them to look the same
